### PR TITLE
Fix memory leaks identified by asan.

### DIFF
--- a/src/famfs_fused.c
+++ b/src/famfs_fused.c
@@ -1694,6 +1694,9 @@ err_out1:
 	if (famfs_data.icache.root.fd >= 0)
 		close(famfs_data.icache.root.fd);
 
+    if (famfs_data.daxdev_table)
+		free(famfs_data.daxdev_table);
+
 	free(famfs_data.source);
 	return ret ? 1 : 0;
 }

--- a/src/famfs_fused.c
+++ b/src/famfs_fused.c
@@ -471,7 +471,7 @@ famfs_do_lookup(
 				 __func__, st.st_size);
 			e->attr = st;
 		} else {
-			void *yaml_buf;
+			void *yaml_buf = NULL;
 			ssize_t yaml_size;
 			ino_t ino = st.st_ino; /* Inode number from file, not yaml */
 
@@ -483,6 +483,10 @@ famfs_do_lookup(
 			if (newfd == -1) {
 				goto out_err;
 			}
+
+			fmeta = calloc(1, sizeof(*fmeta));
+			if (!fmeta)
+				goto out_err;
 		
 			yaml_buf = famfs_read_fd_to_buf(newfd, FAMFS_YAML_MAX,
 							&yaml_size);
@@ -492,16 +496,15 @@ famfs_do_lookup(
 				goto out_err;
 			}
 
-			fmeta = calloc(1, sizeof(*fmeta));
-			if (!fmeta)
-				goto out_err;
-
 			/* Famfs gets the stat struct from the shadow yaml */
 			res = famfs_shadow_to_stat(yaml_buf, yaml_size, &st,
 						   &e->attr, fmeta, 0);
 			if (res)
 				goto out_err;
 			st.st_ino = ino;
+
+			if (yaml_buf)
+				free(yaml_buf);
 		}
 
 		famfs_log(FAMFS_LOG_DEBUG, "               : inode=%d is a file\n",

--- a/src/famfs_fused.c
+++ b/src/famfs_fused.c
@@ -652,7 +652,7 @@ famfs_get_fmap(
 	struct famfs_data *lo = famfs_data(req);
 	ssize_t fmap_bufsize = FMAP_MSG_MAX;
 	struct famfs_inode *inode;
-	char *fmap_message;
+	char *fmap_message = NULL;
 	ssize_t fmap_size;
 	int err = 0;
 
@@ -718,9 +718,16 @@ famfs_get_fmap(
 	if (err)
 		famfs_log(FAMFS_LOG_ERR, "%s: fuse_reply_buf returned err %d\n",
 			 __func__, err);
+
+	if (fmap_message)
+		free(fmap_message);
+
 	return;
 
 out_err:
+	if (fmap_message)
+		free(fmap_message);
+
 	fuse_reply_err(req, err);
 }
 

--- a/src/famfs_mount.c
+++ b/src/famfs_mount.c
@@ -537,6 +537,7 @@ famfs_start_fuse_daemon(
 	char exe_path[PATH_MAX] = { 0 };
 	char opts[PATH_MAX] = { 0 };
 	char *argv[NARGV] = { 0 };
+	char asan_log_path[256];
 	int argc = 0;
 	ssize_t len;
 	char *dir;
@@ -558,6 +559,16 @@ famfs_start_fuse_daemon(
 	dir = dirname(exe_path);
 	snprintf(target_path, sizeof(target_path) - 1, "%s/%s",
 		 dir, "famfs_fused");
+
+	/*
+	 * Set addr sanitizer env option to capture any any sanitizer errors
+	 * into a log file. This is needed as famfs_fused becomes a daemon
+	 * and loses access to stderr, this creates a log in shadow dir if
+	 * asan related errors are encountered.
+	 */
+	snprintf(asan_log_path, sizeof(asan_log_path),
+					"log_path=%s/asan_famfs_fused.log", shadow);
+	setenv("ASAN_OPTIONS", asan_log_path, 1);
 
 	/* fsname=/dev/dax1.0 sets the string in column 1 of /proc/mounts */
 	snprintf(opts, sizeof(opts),


### PR DESCRIPTION
Steps to recreate: Start asan enabled famfs_fused by doing a --fuse mount.

Copy a bunch of small files into famfs.
unmount the filesystem.
A error file is created in /tmp/famfs_shadow_dir

