### PR TITLE
 famfs: fix regression from e26bce

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,6 +178,12 @@ target_link_libraries(famfs libfamfs famfstest uuid z yaml)
 target_link_libraries(mkfs.famfs libfamfs uuid z yaml)
 target_link_libraries(pcq libpcq libfamfs uuid z famfstest yaml)
 
+set_target_properties(famfs_fused
+	PROPERTIES
+		INSTALL_RPATH "/usr/local/lib64"
+		BUILD_WITH_INSTALL_RPATH TRUE
+)
+
 target_link_libraries(famfs_fused
     PRIVATE
         libfamfs
@@ -229,6 +235,7 @@ message("multichase: ${CMAKE_CURRENT_BINARY_DIR}")
 install(TARGETS famfs DESTINATION /usr/local/bin)
 install(TARGETS mkfs.famfs DESTINATION /usr/local/bin)
 install(TARGETS pcq DESTINATION /usr/local/bin)
+install(TARGETS famfs_fused DESTINATION /usr/local/bin)
 
 #Install library and header files? Maybe later...
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,8 +180,9 @@ target_link_libraries(pcq libpcq libfamfs uuid z famfstest yaml)
 
 set_target_properties(famfs_fused
 	PROPERTIES
+		BUILD_WITH_INSTALL_RPATH FALSE
+		CMAKE_SKIP_BUILD_RPATH FALSE
 		INSTALL_RPATH "/usr/local/lib64"
-		BUILD_WITH_INSTALL_RPATH TRUE
 )
 
 target_link_libraries(famfs_fused

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ cmake-modules:
 	git clone https://github.com/jagalactic/cmake-modules.git
 
 libfuse_install:
-	meson install -C $(BUILD)/libfuse
+	meson install -C $(BDIR)/libfuse
 
 threadpool:
 	@echo "Clone C-Thread-Pool"


### PR DESCRIPTION

    binaries in build tree were looking at /usr/local/lib for the
    libfuse library and if it was not installed, errored out.

    fix it by letting the binary to search in build tree also.
    fixes e26bce7a10d987edcef8eb5f8f39d0875f6864a8
