### PR TITLE
Multi Device support - phase 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -288,7 +288,7 @@ coverage_dual_pcq:	coverage
 	sudo chown -R "$(UID):$(GID)" coverage
 	$(MAKE) unit_coverage
 
-release:	cmake-modules threadpool mongoose
+release:	cmake-modules threadpool mongoose ndctl
 	$(call check_kernel_version)
 	mkdir -p release;
 	$(MAKE) libfuse BDIR="release"

--- a/src/famfs_lib.c
+++ b/src/famfs_lib.c
@@ -575,9 +575,11 @@ famfs_gen_superblock_crc(const struct famfs_superblock *sb)
 	crc = crc32(crc, (const unsigned char *)&sb->ts_uuid,
 		    sizeof(sb->ts_uuid));
 	crc = crc32(crc, (const unsigned char *)&sb->ts_dev_uuid,
-		    sizeof(sb->ts_uuid));
+		    sizeof(sb->ts_dev_uuid));
 	crc = crc32(crc, (const unsigned char *)&sb->ts_system_uuid,
 		    sizeof(sb->ts_system_uuid));
+	crc = crc32(crc, (const unsigned char *)&sb->ts_primary_dev_uuid,
+		    sizeof(sb->ts_primary_dev_uuid));
 	return crc;
 }
 
@@ -988,6 +990,41 @@ famfs_check_super(
 			__func__, sb->ts_alloc_unit);
 		return -1;
 	}
+
+	/* Validate primary/secondary superblock flags */
+	if (sb->ts_sb_flags & FAMFS_SECONDARY_SB) {
+		/* Secondary must have ts_primary_dev_uuid populated
+		 * TODO: Verify ts_primary_dev_uuid matches actual primary device uuid
+		 */
+		static const uuid_le null_uuid = {0};
+		if (memcmp(&sb->ts_primary_dev_uuid, &null_uuid,
+			   sizeof(uuid_le)) == 0) {
+			fprintf(stderr,
+				"%s: secondary superblock missing primary UUID\n",
+				__func__);
+			return -1;
+		}
+		/* Secondary must NOT have a log */
+		if (sb->ts_log_offset != 0 || sb->ts_log_len != 0) {
+			fprintf(stderr,
+				"%s: secondary superblock cannot have a log\n",
+				__func__);
+			return -1;
+		}
+	} else if (sb->ts_sb_flags & FAMFS_PRIMARY_SB) {
+		/* Primary should not reference another primary */
+		static const uuid_le null_uuid = {0};
+		if (memcmp(&sb->ts_primary_dev_uuid, &null_uuid,
+			   sizeof(uuid_le)) != 0) {
+			fprintf(stderr,
+				"%s: primary superblock should not reference another primary\n",
+				__func__);
+			return -1;
+		}
+	}
+	/* Note: ts_sb_flags == 0 is allowed for backward compatibility
+	 * with older superblocks that predate multi-device support.
+	 */
 
 	if (log_offset)
 		*log_offset = sb->ts_log_offset;
@@ -5562,6 +5599,10 @@ __famfs_mkfs(const char              *daxdev,
 	/* Note: generated UUIDs are ok now, but we will need to use
 	 * tagged-capacity UUIDs when CXL3 provdies UUIDs as tags */
 	famfs_uuidgen(&sb->ts_dev_uuid);
+
+	/* Mark as primary superblock with no primary reference */
+	sb->ts_sb_flags = FAMFS_PRIMARY_SB;
+	memset(&sb->ts_primary_dev_uuid, 0, sizeof(sb->ts_primary_dev_uuid));
 
 	/* Configure the first daxdev */
 	sb->ts_daxdev.dd_size = device_size;

--- a/src/famfs_lib.c
+++ b/src/famfs_lib.c
@@ -555,31 +555,17 @@ famfs_gen_superblock_crc(const struct famfs_superblock *sb)
 	unsigned long crc = crc32(0L, Z_NULL, 0);
 
 	assert(sb);
-	crc = crc32(crc, (const unsigned char *)&sb->ts_magic,
-		    sizeof(sb->ts_magic));
-	crc = crc32(crc, (const unsigned char *)&sb->ts_version,
-		    sizeof(sb->ts_version));
-	crc = crc32(crc, (const unsigned char *)&sb->ts_log_offset,
-		    sizeof(sb->ts_log_offset));
 
-	crc = crc32(crc, (const unsigned char *)&sb->ts_log_len,
-		    sizeof(sb->ts_log_len));
+	/*
+	 * ts_crc covers every field that precedes it in the superblock. Hash
+	 * the contiguous byte range from the start of the struct up to ts_crc
+	 * (offsetof) rather than enumerating fields, so this stays correct as
+	 * fields are added before ts_crc. (The covered prefix has no internal
+	 * padding, so this is byte-identical to hashing the fields one by one.)
+	 */
+	crc = crc32(crc, (const unsigned char *)sb,
+			offsetof(struct famfs_superblock, ts_crc));
 
-	crc = crc32(crc, (const unsigned char *)&sb->ts_alloc_unit,
-		    sizeof(sb->ts_alloc_unit));
-	crc = crc32(crc, (const unsigned char *)&sb->ts_omf_ver_major,
-		    sizeof(sb->ts_omf_ver_major));
-	crc = crc32(crc, (const unsigned char *)&sb->ts_omf_ver_minor,
-		    sizeof(sb->ts_omf_ver_minor));
-
-	crc = crc32(crc, (const unsigned char *)&sb->ts_uuid,
-		    sizeof(sb->ts_uuid));
-	crc = crc32(crc, (const unsigned char *)&sb->ts_dev_uuid,
-		    sizeof(sb->ts_dev_uuid));
-	crc = crc32(crc, (const unsigned char *)&sb->ts_system_uuid,
-		    sizeof(sb->ts_system_uuid));
-	crc = crc32(crc, (const unsigned char *)&sb->ts_primary_dev_uuid,
-		    sizeof(sb->ts_primary_dev_uuid));
 	return crc;
 }
 

--- a/src/famfs_meta.h
+++ b/src/famfs_meta.h
@@ -38,7 +38,7 @@
 #define FAMFS_STATFS_MAGIC     0x87b282fd /* fuse statfs magic number*/
 #endif
 
-#define FAMFS_CURRENT_VERSION  48
+#define FAMFS_CURRENT_VERSION  49
 
 #define FAMFS_LOG_OFFSET    0x200000 /* 2MiB */
 #define FAMFS_LOG_LEN       0x800000 /* 8MiB */
@@ -59,7 +59,7 @@ static inline size_t round_size_to_alloc_unit(u64 size)
 #define FAMFS_DEVNAME_LEN 64
 
 #define FAMFS_OMF_VER_MAJOR 2
-#define FAMFS_OMF_VER_MINOR 2 /* +FAMFS_LOG_ADD_DAXDEV (additive, backward-compatible) */
+#define FAMFS_OMF_VER_MINOR 3 /* +ts_primary_dev_uuid in superblock */
 
 struct famfs_daxdev {
 	size_t              dd_size;
@@ -85,8 +85,9 @@ struct famfs_superblock {
 	uuid_le             ts_uuid;        /* UUID of this file system */
 	uuid_le             ts_dev_uuid;    /* uuid of this device */
 	uuid_le             ts_system_uuid; /* system uuid */
+	uuid_le             ts_primary_dev_uuid; /* primary's ts_dev_uuid; zero on primary */
 	u64                 ts_crc;         /* Covers all fields prior to this one */
-	u32                 ts_sb_flags;
+	u32                 ts_sb_flags;    /* FAMFS_PRIMARY_SB or FAMFS_SECONDARY_SB */
 	struct famfs_daxdev ts_daxdev;
 };
 

--- a/test/famfs_unit.cpp
+++ b/test/famfs_unit.cpp
@@ -209,6 +209,82 @@ TEST(famfs, famfs_super_test)
 	logp->famfs_log_crc--;
 	rc = famfs_validate_log_header(logp);
 	ASSERT_EQ(rc, 0);
+
+	/* ========================================
+	 * Primary/Secondary superblock tests
+	 * ======================================== */
+
+	/* Test 1: Verify primary superblock has correct flags after mkfs */
+	ASSERT_EQ(sb->ts_sb_flags, (u32)FAMFS_PRIMARY_SB);
+	ASSERT_NE(sb->ts_log_offset, 0ULL);
+	ASSERT_NE(sb->ts_log_len, 0ULL);
+	/* ts_primary_dev_uuid should be zero for primary */
+	{
+		uuid_le null_uuid = {0};
+		ASSERT_EQ(memcmp(&sb->ts_primary_dev_uuid, &null_uuid, sizeof(uuid_le)), 0);
+	}
+	rc = famfs_check_super(sb, NULL, NULL);
+	ASSERT_EQ(rc, 0);
+
+	/* Test 2: Build a valid secondary superblock manually */
+	struct famfs_superblock *sb_secondary;
+	sb_secondary = (struct famfs_superblock *)calloc(1, FAMFS_SUPERBLOCK_SIZE);
+
+	sb_secondary->ts_magic = FAMFS_SUPER_MAGIC;
+	sb_secondary->ts_version = FAMFS_CURRENT_VERSION;
+	sb_secondary->ts_log_offset = 0;  /* Secondary has no log */
+	sb_secondary->ts_log_len = 0;     /* Secondary has no log */
+	sb_secondary->ts_alloc_unit = FAMFS_ALLOC_UNIT;
+	sb_secondary->ts_omf_ver_major = FAMFS_OMF_VER_MAJOR;
+	sb_secondary->ts_omf_ver_minor = FAMFS_OMF_VER_MINOR;
+	memcpy(&sb_secondary->ts_uuid, &sb->ts_uuid, sizeof(uuid_le));  /* Same fs */
+	famfs_uuidgen(&sb_secondary->ts_dev_uuid);  /* Different device UUID */
+	memcpy(&sb_secondary->ts_system_uuid, &sb->ts_system_uuid, sizeof(uuid_le));
+	memcpy(&sb_secondary->ts_primary_dev_uuid, &sb->ts_dev_uuid, sizeof(uuid_le));
+	sb_secondary->ts_sb_flags = FAMFS_SECONDARY_SB;
+	sb_secondary->ts_crc = famfs_gen_superblock_crc(sb_secondary);
+
+	rc = famfs_check_super(sb_secondary, NULL, NULL);
+	ASSERT_EQ(rc, 0);
+
+	/* Test 3: Secondary with missing ts_primary_dev_uuid should fail */
+	{
+		uuid_le null_uuid = {0};
+		memcpy(&sb_secondary->ts_primary_dev_uuid, &null_uuid, sizeof(uuid_le));
+		sb_secondary->ts_crc = famfs_gen_superblock_crc(sb_secondary);
+		rc = famfs_check_super(sb_secondary, NULL, NULL);
+		ASSERT_EQ(rc, -1);
+		/* Restore */
+		memcpy(&sb_secondary->ts_primary_dev_uuid, &sb->ts_dev_uuid, sizeof(uuid_le));
+		sb_secondary->ts_crc = famfs_gen_superblock_crc(sb_secondary);
+	}
+
+	/* Test 4: Secondary with non-zero ts_log_offset should fail */
+	sb_secondary->ts_log_offset = FAMFS_LOG_OFFSET;
+	sb_secondary->ts_crc = famfs_gen_superblock_crc(sb_secondary);
+	rc = famfs_check_super(sb_secondary, NULL, NULL);
+	ASSERT_EQ(rc, -1);
+	/* Restore */
+	sb_secondary->ts_log_offset = 0;
+	sb_secondary->ts_crc = famfs_gen_superblock_crc(sb_secondary);
+
+	/* Test 5: Primary with populated ts_primary_dev_uuid should fail */
+	memcpy(&sb->ts_primary_dev_uuid, &sb_secondary->ts_dev_uuid, sizeof(uuid_le));
+	sb->ts_crc = famfs_gen_superblock_crc(sb);
+	rc = famfs_check_super(sb, NULL, NULL);
+	ASSERT_EQ(rc, -1);
+	/* Restore */
+	{
+		uuid_le null_uuid = {0};
+		memcpy(&sb->ts_primary_dev_uuid, &null_uuid, sizeof(uuid_le));
+		sb->ts_crc = famfs_gen_superblock_crc(sb);
+	}
+	rc = famfs_check_super(sb, NULL, NULL);
+	ASSERT_EQ(rc, 0);
+
+	free(sb_secondary);
+	free(sb);
+	free(logp);
 }
 
 #define SB_RELPATH ".meta/.superblock"
@@ -1854,8 +1930,8 @@ TEST(famfs, famfs_log_add_daxdev_entry)
 
 	/* OMF version constants bumped for the additive log entry type */
 	ASSERT_EQ(FAMFS_OMF_VER_MAJOR, 2);
-	ASSERT_EQ(FAMFS_OMF_VER_MINOR, 2);
-	ASSERT_EQ(FAMFS_CURRENT_VERSION, 48);
+	ASSERT_EQ(FAMFS_OMF_VER_MINOR, 3);
+	ASSERT_EQ(FAMFS_CURRENT_VERSION, 49);
 
 	/* A minimal in-memory log - no device, fs, or root required */
 	logp = (struct famfs_log *)calloc(1, FAMFS_LOG_LEN);


### PR DESCRIPTION
This adds changes as per pahse 2 defined in the design doc. It makes below changes.

Add ts_primary_dev_uuid before ts_crc.
Set FAMFS_PRIMARY_SB in __famfs_mkfs()
 Secondary has ts_log_offset = 0 validation
 Version bump
Test 1: Primary has correct flags
 Test 2: Valid secondary accepted
Test 3: Reject secondary with non-zero log
famfs_check_super() rejects a secondary whose ts_primary_dev_uuid doesn't match the running primary's ts_dev_uuid


Fix a makefile dependency issue.
Fix a typo in crc calculation function