### PR TITLE
Makefile: add ndctl dependency to release target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -288,7 +288,7 @@ coverage_dual_pcq:	coverage
 	sudo chown -R "$(UID):$(GID)" coverage
 	$(MAKE) unit_coverage
 
-release:	cmake-modules threadpool mongoose
+release:	cmake-modules threadpool mongoose ndctl
 	$(call check_kernel_version)
 	mkdir -p release;
 	$(MAKE) libfuse BDIR="release"


### PR DESCRIPTION
The release target was missing ndctl as a dependency, causing build failures when daxctl_dev_enable_famfs() was not found. The debug, sanitize, and coverage targets already include ndctl - this aligns release with them.